### PR TITLE
Removes undefined behavior (GCC 6.2.1 warning).

### DIFF
--- a/generators/active/active.c
+++ b/generators/active/active.c
@@ -60,7 +60,7 @@ typedef struct _active_ring_t {
   uint32_t max;
   uint32_t current;
   uint32_t offset[TREND_POINTS];
-  uint32_t cnt_dist[MAX_DISTRO];
+  uint32_t cnt_dist[MAX_DISTRO+1];
   active_el_t *el_set;
   uint64_t nextid;
   uint64_t keys_generated;

--- a/generators/twolevel/active_ring.h
+++ b/generators/twolevel/active_ring.h
@@ -43,7 +43,7 @@ struct _active_ring_t {
 	uint32_t max;
 	uint32_t current;
 	uint32_t offset[TREND_POINTS];
-	uint32_t cnt_dist[MAX_DISTRO];
+	uint32_t cnt_dist[MAX_DISTRO+1];
 	uint8_t * el_set;
 	uint64_t nextid;
 	uint64_t keys_generated;


### PR DESCRIPTION
The `generate_cnt_distribution` function in two of the generators executes a loop over the inclusive range 0:MAX_DISTRO. The `cnt_dist` array is written to and should therefore be of size MAX_DISTRO+1.

GCC 6.2.1 gives me an undefined behavior warning for this in `active.c:195`.
