### PR TITLE
Adds extra includes to compile on ArchLinux + G++ 6.2.1

### DIFF
--- a/analytics/anomaly2/c++/anomaly2.cpp
+++ b/analytics/anomaly2/c++/anomaly2.cpp
@@ -13,12 +13,15 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#include <argp.h> // Argument parsing
+
 #include <stdexcept>
 #include <signal.h>
 #include <netinet/in.h>
 #include <sys/errno.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h> // ::close()
 
 #include <vector>
 #include <tr1/unordered_map>

--- a/analytics/anomaly3/c++/anomaly3.cpp
+++ b/analytics/anomaly3/c++/anomaly3.cpp
@@ -14,12 +14,15 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#include <argp.h> // Argument parsing
+
 #include <stdexcept>
 #include <signal.h>
 #include <netinet/in.h>
 #include <sys/errno.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h> // ::close()
 
 #include <vector>
 #include <tr1/unordered_map>


### PR DESCRIPTION
There were two C includes required to compile on my machine. I assume that they are required on other configurations, too.
